### PR TITLE
Add Jest tests for fetchTopCoins

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+};

--- a/backend/utils/__tests__/coinmarketcap.test.js
+++ b/backend/utils/__tests__/coinmarketcap.test.js
@@ -1,0 +1,51 @@
+const fetch = require('node-fetch');
+const fetchTopCoins = require('../coinmarketcap');
+
+jest.mock('node-fetch');
+
+describe('fetchTopCoins', () => {
+  it('returns simplified coin data', async () => {
+    process.env.CMC_API_KEY = 'test-key';
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue({
+        data: [
+          {
+            id: 1,
+            name: 'Bitcoin',
+            symbol: 'BTC',
+            quote: {
+              USD: {
+                price: 50000,
+                market_cap: 1000000,
+                volume_24h: 10000,
+                percent_change_24h: 2,
+                percent_change_7d: 5,
+                percent_change_30d: 10,
+                percent_change_90d: 20,
+              }
+            }
+          }
+        ]
+      })
+    };
+    fetch.mockResolvedValue(mockResponse);
+
+    const result = await fetchTopCoins(1);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: 'Bitcoin',
+        symbol: 'BTC',
+        price: 50000,
+        market_cap: 1000000,
+        volume: 10000,
+        percent_change_1d: 2,
+        percent_change_7d: 5,
+        percent_change_30d: 10,
+        percent_change_90d: 20
+      }
+    ]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "@supabase/supabase-js": "^2.49.4",
     "openai": "^4.91.1",
     "react-markdown": "^10.1.0"
+  },
+  "scripts": {
+    "test": "node ./frontend/node_modules/jest/bin/jest.js --config backend/jest.config.js"
   }
 }


### PR DESCRIPTION
## Summary
- add backend Jest config
- add coinmarketcap utils test
- wire up npm test script to run Jest

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884778ee2f4832d8656c2baf901a22a