### PR TITLE
Add Jest dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "devDependencies": {
         "dotenv": "^16.4.7",
         "netlify-cli": "^19.1.5",
-        "node-fetch": "^2.7.0"
+        "node-fetch": "^2.7.0",
+        "jest": "^29.7.0"
       }
     },
     "node_modules/@supabase/auth-js": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "devDependencies": {
     "dotenv": "^16.4.7",
     "netlify-cli": "^19.1.5",
-    "node-fetch": "^2.7.0"
+    "node-fetch": "^2.7.0",
+    "jest": "^29.7.0"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",


### PR DESCRIPTION
## Summary
- add `jest` under devDependencies in `package.json`
- reflect the change in `package-lock.json`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/crypto-sentinel/node_modules/.bin/jest')*
- `npm install` *(fails: 403 Forbidden GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68848b0650dc832db3f97e6778d2fc6d